### PR TITLE
feat: support sitemap input from file or URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Once built, you can run the tool from the command line. The tool supports both i
 
 ```bash
 $ ./sitemapExport
-Enter the Sitemap or RSS feed URL (required): https://example.com/sitemap.xml
+Enter the Sitemap or RSS feed URL or file path (required): https://example.com/sitemap.xml
 Enter the CSS selector to extract content (default: body):
 Enter the output filename (default: output): output
 Enter the output file type (txt, json, jsonl, md, pdf) (default: txt): jsonl
@@ -78,13 +78,13 @@ This will crawl the provided sitemap, extract content from each page using the C
 If you prefer to pass flags instead of interactive prompts, you can run:
 
 ```bash
-./sitemapExport --url="https://example.com/sitemap.xml" --css="body" --filename="output" --type="txt" --format="txt"
+./sitemapExport --input="https://example.com/sitemap.xml" --css="body" --filename="output" --type="txt" --format="txt"
 ```
 
 Or, use the short flags:
 
 ```bash
-./sitemapExport --u="https://example.com/sitemap.xml" --c="body" --n="output" --t="txt" --f="txt"
+./sitemapExport -i="https://example.com/sitemap.xml" -c="body" -n="output" -t="txt" -f="txt"
 ```
 
 ### Supported Formats

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -3,35 +3,51 @@ package feed
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 )
 
-// DetectFeedType detects whether the URL is an RSS feed or sitemap based on the XML root element.
-func DetectFeedType(feedURL string) (string, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second, // Set a timeout to avoid long-running requests
-	}
+// DetectFeedType detects whether the provided source is an RSS feed or sitemap
+// based on the XML root element. The source can be either a URL or a file path.
+func DetectFeedType(feedSource string) (string, error) {
+	var (
+		reader io.ReadCloser
+		err    error
+	)
 
-	// Fetch the feed URL
-	res, err := client.Get(feedURL)
-	if err != nil {
-		return "", fmt.Errorf("error fetching URL %s: %w", feedURL, err)
+	if strings.HasPrefix(feedSource, "http://") || strings.HasPrefix(feedSource, "https://") {
+		client := &http.Client{
+			Timeout: 10 * time.Second, // Set a timeout to avoid long-running requests
+		}
+		// Fetch the feed URL
+		res, err := client.Get(feedSource)
+		if err != nil {
+			return "", fmt.Errorf("error fetching URL %s: %w", feedSource, err)
+		}
+		if res.StatusCode != http.StatusOK {
+			res.Body.Close()
+			return "", fmt.Errorf("unexpected HTTP status: %d %s", res.StatusCode, http.StatusText(res.StatusCode))
+		}
+		reader = res.Body
+	} else {
+		// Open local file
+		reader, err = os.Open(feedSource)
+		if err != nil {
+			return "", fmt.Errorf("error opening file %s: %w", feedSource, err)
+		}
 	}
-	defer res.Body.Close()
-
-	// Check for non-200 status codes
-	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected HTTP status: %d %s", res.StatusCode, http.StatusText(res.StatusCode))
-	}
+	defer reader.Close()
 
 	// Parse the XML root element to detect the feed type
 	var root struct {
 		XMLName xml.Name
 	}
-	decoder := xml.NewDecoder(res.Body)
+	decoder := xml.NewDecoder(reader)
 	if err := decoder.Decode(&root); err != nil {
-		return "", fmt.Errorf("error decoding XML from %s: %w", feedURL, err)
+		return "", fmt.Errorf("error decoding XML from %s: %w", feedSource, err)
 	}
 
 	// Detect based on the root element's XML name
@@ -41,6 +57,6 @@ func DetectFeedType(feedURL string) (string, error) {
 	case "rss":
 		return "rss", nil
 	default:
-		return "", fmt.Errorf("unknown feed type for URL %s", feedURL)
+		return "", fmt.Errorf("unknown feed type for %s", feedSource)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	feedURL        string
+	feedSource     string
 	cssSelector    string
 	outputFilename string
 	outputFiletype string
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	// Define flags in the init function
-	rootCmd.Flags().StringVarP(&feedURL, "url", "u", "", "Sitemap or RSS feed URL to crawl (required)")
+	rootCmd.Flags().StringVarP(&feedSource, "input", "i", "", "Sitemap or RSS feed URL or file path to crawl (required)")
 	rootCmd.Flags().StringVarP(&cssSelector, "css", "c", "body", "CSS selector to extract content (for sitemaps)")
 	rootCmd.Flags().StringVarP(&outputFilename, "filename", "n", "output", "Filename for the output")
 	rootCmd.Flags().StringVarP(&outputFiletype, "type", "t", "txt", "File output format (txt, json, jsonl, md, pdf)")
@@ -46,9 +46,9 @@ func init() {
 // executeCrawlAndExport prompts the user for missing input (if flags are not provided), validates the inputs, and runs the main export logic.
 func executeCrawlAndExport(cmd *cobra.Command, args []string) {
 	// Prompt for missing user input
-	feedURL = promptUser("Enter the Sitemap or RSS feed URL (required): ", feedURL)
-	if feedURL == "" {
-		handleError("getting feed URL", fmt.Errorf("feed URL is required"))
+	feedSource = promptUser("Enter the Sitemap or RSS feed URL or file path (required): ", feedSource)
+	if feedSource == "" {
+		handleError("getting feed source", fmt.Errorf("feed source is required"))
 	}
 
 	cssSelector = promptUser("Enter the CSS selector to extract content (default: 'body'): ", cssSelector)
@@ -68,7 +68,7 @@ func executeCrawlAndExport(cmd *cobra.Command, args []string) {
 
 	// Confirm the input values with the user before proceeding
 	fmt.Printf("\nExport data with the following settings:\n")
-	fmt.Printf("URL: %s\n", feedURL)
+	fmt.Printf("Input: %s\n", feedSource)
 	fmt.Printf("CSS Selector: %s\n", cssSelector)
 	fmt.Printf("Output Filename: %s\n", outputFilename)
 	fmt.Printf("Output Filetype: %s\n", outputFiletype)
@@ -82,7 +82,7 @@ func executeCrawlAndExport(cmd *cobra.Command, args []string) {
 	fmt.Print("\n")
 
 	// Step 1: Detect if it's an RSS feed or a Sitemap
-	feedType, err := feed.DetectFeedType(feedURL)
+	feedType, err := feed.DetectFeedType(feedSource)
 	handleError("detecting feed type", err)
 
 	// Step 2: Fetch and crawl the pages based on the feed type
@@ -90,11 +90,11 @@ func executeCrawlAndExport(cmd *cobra.Command, args []string) {
 	switch feedType {
 	case "rss":
 		// Crawl RSS feed
-		pages, err = crawler.CrawlRSS(feedURL, cssSelector, format)
+		pages, err = crawler.CrawlRSS(feedSource, cssSelector, format)
 		handleError("crawling RSS feed", err)
 	case "sitemap":
 		// Crawl Sitemap
-		pages, err = crawler.CrawlSitemap(feedURL, cssSelector, format)
+		pages, err = crawler.CrawlSitemap(feedSource, cssSelector, format)
 		handleError("crawling sitemap", err)
 	default:
 		handleError("processing feed", fmt.Errorf("unknown feed type detected"))


### PR DESCRIPTION
## Summary
- allow providing sitemap or RSS feed as either a URL or file path
- detect feed type from local files and crawl sitemaps/RSS feeds from disk
- document new `--input` flag accepting URLs or paths

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0734094bc832eaade979b71f06593