### PR TITLE
feat: add shared HTTP client and CLI overrides

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -56,7 +55,7 @@ func CrawlSitemap(sitemapSource, cssSelector, format, filter string) ([]Page, er
 
 	if strings.HasPrefix(sitemapSource, "http://") || strings.HasPrefix(sitemapSource, "https://") {
 		// Fetch the sitemap from URL
-		res, err := http.Get(sitemapSource)
+		res, err := Client.Get(sitemapSource)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch sitemap: %w", err)
 		}
@@ -115,7 +114,7 @@ func CrawlRSS(rssSource, cssSelector, format, filter string) ([]Page, error) {
 
 	if strings.HasPrefix(rssSource, "http://") || strings.HasPrefix(rssSource, "https://") {
 		// Fetch the RSS feed from URL
-		res, err := http.Get(rssSource)
+		res, err := Client.Get(rssSource)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch RSS feed: %w", err)
 		}
@@ -169,7 +168,7 @@ func CrawlRSS(rssSource, cssSelector, format, filter string) ([]Page, error) {
 
 // extractPage fetches a page and extracts its content based on a CSS selector and format.
 func extractPage(pageURL, cssSelector, format string) (Page, error) {
-	res, err := http.Get(pageURL)
+	res, err := Client.Get(pageURL)
 	if err != nil {
 		return Page{}, fmt.Errorf("error visiting URL %s: %w", pageURL, err)
 	}

--- a/crawler/httpclient.go
+++ b/crawler/httpclient.go
@@ -1,0 +1,34 @@
+package crawler
+
+import (
+	"net/http"
+	"time"
+)
+
+var (
+	// Client is the shared HTTP client used by crawler and feed packages.
+	Client    = &http.Client{Timeout: 10 * time.Second}
+	userAgent = "sitemapExport"
+)
+
+type userAgentTransport struct {
+	base http.RoundTripper
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	return t.base.RoundTrip(req)
+}
+
+func init() {
+	Client.Transport = &userAgentTransport{base: http.DefaultTransport}
+}
+
+// SetUserAgent allows overriding the User-Agent header for HTTP requests.
+func SetUserAgent(ua string) {
+	if ua != "" {
+		userAgent = ua
+	}
+}

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -7,7 +7,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
+
+	"sitemapExport/crawler"
 )
 
 // DetectFeedType detects whether the provided source is an RSS feed or sitemap
@@ -19,11 +20,8 @@ func DetectFeedType(feedSource string) (string, error) {
 	)
 
 	if strings.HasPrefix(feedSource, "http://") || strings.HasPrefix(feedSource, "https://") {
-		client := &http.Client{
-			Timeout: 10 * time.Second, // Set a timeout to avoid long-running requests
-		}
 		// Fetch the feed URL
-		res, err := client.Get(feedSource)
+		res, err := crawler.Client.Get(feedSource)
 		if err != nil {
 			return "", fmt.Errorf("error fetching URL %s: %w", feedSource, err)
 		}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"sitemapExport/formatter"
 	"sitemapExport/writer"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,8 @@ var (
 	outputFiletype string
 	format         string
 	urlFilter      string
+	timeout        time.Duration
+	userAgent      string
 )
 
 func main() {
@@ -43,6 +46,8 @@ func init() {
 	rootCmd.Flags().StringVarP(&outputFiletype, "type", "t", "txt", "File output format (txt, json, jsonl, md, pdf)")
 	rootCmd.Flags().StringVarP(&format, "format", "f", "txt", "Content format transformation (html, md, txt)")
 	rootCmd.Flags().StringVar(&urlFilter, "filter", "*", "Only include URLs matching this pattern (e.g., blog/*)")
+	rootCmd.Flags().DurationVar(&timeout, "timeout", 10*time.Second, "HTTP client timeout")
+	rootCmd.Flags().StringVar(&userAgent, "user-agent", "sitemapExport", "User-Agent header for HTTP requests")
 }
 
 // executeCrawlAndExport prompts the user for missing input (if flags are not provided), validates the inputs, and runs the main export logic.
@@ -94,6 +99,10 @@ func executeCrawlAndExport(cmd *cobra.Command, args []string) {
 		return
 	}
 	fmt.Print("\n")
+
+	// Apply HTTP client settings
+	crawler.Client.Timeout = timeout
+	crawler.SetUserAgent(userAgent)
 
 	// Step 1: Detect if it's an RSS feed or a Sitemap
 	feedType, err := feed.DetectFeedType(feedSource)


### PR DESCRIPTION
## Summary
- introduce shared HTTP client with default timeout and user-agent support
- use shared client across crawler and feed and allow overriding via CLI flags
- support configurable HTTP timeout and user-agent from command line

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0af0f73b4832e9afebb84e5235daa